### PR TITLE
Per Session Statistics, used for the upgrades system

### DIFF
--- a/src/main/java/me/yhamarsheh/islandclash/game/session/SessionalStatistics.java
+++ b/src/main/java/me/yhamarsheh/islandclash/game/session/SessionalStatistics.java
@@ -1,0 +1,31 @@
+package me.yhamarsheh.islandclash.game.session;
+
+import me.yhamarsheh.islandclash.storage.objects.HPlayer;
+
+public class SessionalStatistics {
+
+    // No need to add all of the data, since we wont be using them.
+    private int kills;
+    private int hyions;
+
+    private final HPlayer hPlayer;
+    public SessionalStatistics(HPlayer hPlayer) {
+        this.hPlayer = hPlayer;
+    }
+
+    public void setKills(int kills) {
+        this.kills = kills;
+    }
+
+    public void setHyions(int hyions) {
+        this.hyions = hyions;
+    }
+
+    public int getKills() {
+        return kills;
+    }
+
+    public int getHyions() {
+        return hyions;
+    }
+}

--- a/src/main/java/me/yhamarsheh/islandclash/guis/UpgradesGUI.java
+++ b/src/main/java/me/yhamarsheh/islandclash/guis/UpgradesGUI.java
@@ -1,5 +1,7 @@
 package me.yhamarsheh.islandclash.guis;
 
+import com.google.common.collect.Sets;
+import dev.triumphteam.gui.components.InteractionModifier;
 import dev.triumphteam.gui.guis.Gui;
 import me.yhamarsheh.islandclash.IslandClash;
 import me.yhamarsheh.islandclash.storage.objects.HPlayer;
@@ -15,6 +17,11 @@ public class UpgradesGUI {
         this.plugin = plugin;
         this.hPlayer = hPlayer;
 
-        this.gui = new Gui(6, "", new HashSet<>().);
+        this.gui = new Gui(6, "Upgrades", Sets.newHashSet(InteractionModifier.PREVENT_ITEM_DROP, InteractionModifier.PREVENT_ITEM_TAKE
+        , InteractionModifier.PREVENT_ITEM_PLACE, InteractionModifier.PREVENT_ITEM_SWAP));
+    }
+
+    private void setupGui() {
+
     }
 }

--- a/src/main/java/me/yhamarsheh/islandclash/storage/objects/HPlayer.java
+++ b/src/main/java/me/yhamarsheh/islandclash/storage/objects/HPlayer.java
@@ -1,6 +1,7 @@
 package me.yhamarsheh.islandclash.storage.objects;
 
 import me.yhamarsheh.islandclash.IslandClash;
+import me.yhamarsheh.islandclash.game.session.SessionalStatistics;
 import me.yhamarsheh.islandclash.game.upgrades.PlayerUpgrades;
 import me.yhamarsheh.islandclash.leveling.Rank;
 import me.yhamarsheh.islandclash.storage.SQLDatabase;
@@ -36,12 +37,14 @@ public class HPlayer {
 
     // s
     private PlayerUpgrades playerUpgrades;
+    private SessionalStatistics sessionalStatistics;
 
     public HPlayer(IslandClash plugin, UUID uuid) {
         this.plugin = plugin;
         this.uuid = uuid;
         this.rank = Rank.UNRANKED;
         this.playerUpgrades = new PlayerUpgrades(this);
+        this.sessionalStatistics = new SessionalStatistics(this);
 
         this.sql = plugin.getSQLDatabase();
         create(); // No need to call Async, since this constructor is used in an Async Event. (AsyncPlayerPreLoginEvent)
@@ -51,13 +54,17 @@ public class HPlayer {
      * Class Functions
      */
     public void addKill() {
-        player.setHealth(player.getHealth() + 4);
+        int toAdd = (int) (20 - player.getHealth());
+        if (toAdd > 4) toAdd = 4;
+
+        player.setHealth(player.getHealth() + toAdd);
         setKills(kills + 1);
         addStreak();
     }
 
     public void setKills(int kills) {
         this.kills = kills;
+        sessionalStatistics.setKills(kills);
     }
 
     public int getKills() {
@@ -151,6 +158,7 @@ public class HPlayer {
 
     public void setHyions(int hyions) {
         this.hyions = hyions;
+        sessionalStatistics.setHyions(hyions);
     }
 
     public int getHyions() {
@@ -207,9 +215,11 @@ public class HPlayer {
         return playerUpgrades.getProtectionUpgrade().getLevel() > 0;
     }
 
-
     public PlayerUpgrades getPlayerUpgrades() {
         return playerUpgrades;
+    }
+    public SessionalStatistics getSessionalStatistics() {
+        return sessionalStatistics;
     }
 
     /*


### PR DESCRIPTION
# Per Session Statistics. Used for the Upgrades System as follows:
- Instead of players being able to buy upgrades such as sharpness through their lifetime Hyions, they must play the game and get a certain amount of Hyions in order to buy the upgrades.

### Further Explanation:
- The player sessional statistics reset whenever they join, so for them to purchase lets say the sharpness upgrade which would cost like 100 hyions, they must play and get 100 hyions to buy that upgrade, EVEN though if they have 10,000 lifetime Hyions.
- The lifetime Hyions are used to purchase cosmetics, tools, via the Item Shop.